### PR TITLE
Non-found footnote ref no longer outputs unescaped text.

### DIFF
--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -374,7 +374,7 @@ function M.new(writer, options)
       if found then
         return writer.note(parse_blocks(found))
       else
-        return {"[^", ref, "]"}
+        return {"[", parse_inlines("^" .. ref), "]"}
       end
     end
   end


### PR DESCRIPTION
The current version of lunamark does not properly escape non-found footnote refs.

```bash
$ lunamark -t latex -Xnotes <<<'^this gets escaped and [^this does not]'
\^{}this gets escaped and [^this does not]
```

This commit fixes the bug.