### PR TITLE
Added support for Pandoc-style citations.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,7 @@ Lunamark's markdown parser currently supports a number of extensions
   - Footnotes
   - Definition lists
   - Pandoc-style title blocks
+  - Pandoc-style citations
   - Fenced code blocks
   - Flexible metadata using lua declarations
 

--- a/bin/lunamark
+++ b/bin/lunamark
@@ -28,6 +28,7 @@ can be turned on or off individually):
   - Definition lists
   - Metadata
   - Pandoc title blocks
+  - Pandoc citations
   - Fenced code blocks
 
 More extensions will be supported in later versions.
@@ -49,9 +50,10 @@ It is slightly faster than the author's own C library
 `--extensions,-X` *extensions*
 :   Use the specified syntax extensions in parsing markdown.
     *extensions* is a comma-separated list of extensions, each optionally
-    prefixed by `+` (enable) or `-` (disable).  See EXTENSIONS, below, for
-    a list of supported extensions.  The keyword 'all' may also be used,
-    to set all extensions simultaneously.
+    prefixed with `-` (disable), `+` (enable), or followed by
+    `=parameter` (enable and parametrize).  See EXTENSIONS, below, for
+    a list of supported extensions.  The keyword 'all' may also be
+    used, to set all extensions simultaneously.
 `--output,-o` *file*
 :   Write output to *file*.
 `--standalone,-s`
@@ -134,6 +136,40 @@ environment variable `LUNAMARK_EXTENSIONS` (see ENVIRONMENT below).
             (paragraph two of definition one.)
 
         :   a ruby build system.
+
+`(-) citations`
+:   Pandoc citations. Citations go inside square brackets and are
+    separated by semicolons. Each citation must have a key, composed
+    of `@` + the citation identifier from the database, and may
+    optionally have a prenote, and a postnote. The citation key must
+    begin with a letter, digit, or `_`, and may contain alphanumerics,
+    `_`, and internal punctuation characters (`:.#$%&-+?<>~/`).
+    Examples:
+
+        Blah blah [see @doe99, pp. 33-35; also @smith04, chap. 1].
+
+        Blah blah [@doe99, pp. 33-35, 38-39 and *passim*].
+
+        Blah blah [@smith04; @doe99].
+
+    A minus sign (`-`) before the `@` will suppress mention of the
+    author in the citation. This can be useful when the author is
+    already mentioned in the text:
+
+        Smith says blah [-@smith04].
+
+    You can also write an in-text citation, as follows:
+
+        @smith04 says blah.
+
+        @smith04 [p. 33] says blah.
+
+    Some writers will accept finer-grained configuration of the
+    citations extension via `-X citations=configuration`.
+
+`(+) citation_nbsps`
+:   Convert any spacing in citation prenotes and postnotes into
+    non-breaking spaces.
 
 `(-) fenced_code_blocks`
 :   Fenced code blocks. A code fence is a sequence of at least three
@@ -326,8 +362,9 @@ LAYOUT can be default, compact (no unnecessary blank lines), or
 minimize (no unnecessary blank space).
 
 EXTENSIONS is a comma-separated list of extensions, each optionally prefixed
-by + (enable) or - (disable).  The following extensions are defined,
-with the default setting given in parentheses:
+with - (disable), + (enable), or followed by `=parameter` (enable and
+parametrize). The following extensions are defined, with the default setting
+given in parentheses:
   (-) containers           Put sections in containers (e.g. div or section tags)
   (-) slides               Like containers, but do not nest them
   (-) startnum             Start number of an ordered list is significant
@@ -335,7 +372,15 @@ with the default setting given in parentheses:
   (-) preserve_tabs        Don't expand tabs to spaces
   (-) notes                Footnotes
   (-) definition_lists     Definition lists
+  (-) citations            Citations
+  (+) citation_nbsps       Turn spacing into non-breaking spaces in citations
   (-) fenced_code_blocks   Fenced code blocks
+  (-) lua_metadata         Lua metadata
+  (-) pandoc_title_blocks  Pandoc style title blocks
+  (-) hash_enumerators     # may be used as ordered list enumerator
+  (-) require_blank_before_blockquote
+  (-) require_blank_before_header
+  (-) require_blank_before_fenced_code_block
 The keyword 'all' may also be used, to set all extensions simultaneously.
 Setting the environment variable LUNAMARK_EXTENSIONS can change the
 defaults.
@@ -381,6 +426,8 @@ local extensions = {  -- defaults
   smart = false,
   preserve_tabs = false,
   notes = false,
+  citations = false,
+  citation_nbsps = true,
   definition_lists = false,
   fenced_code_blocks = false,
   lua_metadata = false,
@@ -397,12 +444,19 @@ end
 
 local default_extensions = os.getenv("LUNAMARK_EXTENSIONS") or ""
 local extensions_opt = default_extensions .. "," .. (optarg.X or "")
-for x in extensions_opt:gmatch("[%+%-]?[%a_]+") do
+for x in extensions_opt:gmatch("[%+%-]?[%a_=]+") do
   local val = true
-  if x:sub(1,1) == "+" then
-    val = true
+  if x:find("=") then
+    x, val = x:match("([%+%-]?[%a_]+)=([%a_]+)")
+    if x:find("^[%+%-]") then
+      lunamark.util.err("You may either:\n" ..
+        " - disable an extension (-" .. x:sub(2) .. "),\n" ..
+        " - enable an extension (+" .. x:sub(2) .. "), or\n" ..
+        " - enable and parametrize an extension (" .. x:sub(2) .. "=parameter).")
+    end
+  elseif x:find("^%+") then
     x = x:sub(2)
-  elseif x:sub(1,1) == "-" then
+  elseif x:find("^%-") then
     val = false
     x = x:sub(2)
   end
@@ -410,8 +464,6 @@ for x in extensions_opt:gmatch("[%+%-]?[%a_]+") do
     for k,_ in pairs(extensions) do
       extensions[k] = val
     end
-  elseif type(extensions[x]) ~= "boolean" then
-    lunamark.util.err("Unrecognized extension: " .. x, 15)
   else
     extensions[x] = val
   end

--- a/lunamark/writer/docbook.lua
+++ b/lunamark/writer/docbook.lua
@@ -17,6 +17,8 @@ function M.new(options)
 
   Docbook.linebreak = "<literallayout>&#xA;</literallayout>"
 
+  Docbook.nbsp = "&nbsp;"
+
   function Docbook.code(s)
     return {"<literal>",Docbook.string(s),"</literal>"}
   end

--- a/lunamark/writer/groff.lua
+++ b/lunamark/writer/groff.lua
@@ -28,6 +28,8 @@ function M.new(options)
 
   Groff.ndash = "\\[en]"
 
+  Groff.nbsp = "\\~"
+
   function Groff.singlequoted(s)
     return {"`",s,"'"}
   end

--- a/lunamark/writer/html.lua
+++ b/lunamark/writer/html.lua
@@ -36,6 +36,7 @@ function M.new(options)
 
   Html.container = "div"
   Html.linebreak = "<br/>"
+  Html.nbsp = "&nbsp;"
 
   function Html.code(s)
     return {"<code>", Html.string(s), "</code>"}

--- a/lunamark/writer/latex.lua
+++ b/lunamark/writer/latex.lua
@@ -11,6 +11,18 @@ local util = require("lunamark.util")
 local format = string.format
 
 --- Returns a new LaTeX writer.
+--
+-- *   `options` is a table with parsing options.
+--     The following fields are significant:
+--
+--     `citations`
+--     :   Enable citations as in pandoc. Either a boolean or one of
+--         the following strings should be specified:
+--
+--         - `latex`    -- produce basic LaTeX2e citations,
+--         - `natbib`   -- produce citations for the Natbib package, or
+--         - `biblatex` -- produce citations for the BibLaTeX package.
+--
 -- For a list of fields in the writer, see [lunamark.writer.generic].
 function M.new(options)
   options = options or {}
@@ -90,6 +102,105 @@ function M.new(options)
 
   function LaTeX.note(contents)
     return {"\\footnote{",contents,"}"}
+  end
+
+  local function citation_optargs(cite)
+    if cite.prenote and cite.postnote then
+      return {"[", cite.prenote, "][", cite.postnote, "]"}
+    elseif cite.prenote and not cite.postnote then
+      return {"[", cite.prenote, "][]"}
+    elseif not cite.prenote and cite.postnote then
+      return {"[", cite.postnote, "]"}
+    else
+      return ""
+    end
+  end
+
+  if options.citations == true or options.citations == "latex" then
+    --- Basic LaTeX2e citations
+    function LaTeX.citations(_, cites)
+      local buffer = {}
+      local opened_braces = false
+      for i, cite in ipairs(cites) do
+        if cite.prenote or cite.postnote then -- A separate complex citation
+          buffer[#buffer + 1] = {opened_braces and "}" or "",
+            cite.prenote and {i == 1 and "" or " ", cite.prenote, "~"} or
+            "", {(i == 1 or cite.prenote) and "" or " ", "\\cite"},
+            cite.postnote and {"[", cite.postnote, "]"} or "", "{", cite.name,
+            cite_postnote and {"~", cite_postnote} or "", "}"}
+          opened_braces = false
+        else -- A string of simple citations
+          buffer[#buffer + 1] = {opened_braces and ", " or {i == 1 and "" or
+            " ", "\\cite{"}, cite.name}
+          opened_braces = true
+        end
+      end
+      if opened_braces then
+        buffer[#buffer + 1] = "}"
+      end
+      return buffer
+    end
+  elseif options.citations == "natbib" then
+    --- NatBib citations
+    function LaTeX.citations(text_cites, cites)
+      if #cites == 1 then -- A single citation
+        local cite = cites[1]
+        if text_cites then
+          return {"\\citet", citation_optargs(cite), "{", cite.name, "}"}
+        else
+          return {cite.suppress_author and "\\citeyearpar" or "\\citep",
+            citation_optargs(cite), "{", cite.name, "}"}
+        end
+      else -- A string of citations
+        local complex = false
+        local last_suppressed = nil
+        for _, cite in ipairs(cites) do
+          if cite.prenote or cite.postnote or
+             cite.suppress_author == not last_suppressed then
+            complex = true
+            break
+          end
+          last_suppressed = cite.suppress_author
+        end
+        if complex then -- A string of complex citations
+          local buffer = {"\\citetext{"}
+          for i, cite in ipairs(cites) do
+            buffer[#buffer + 1] = {i ~= 1 and "; " or "", cite.suppress_author
+              and "\\citeyear" or (text_cites and "\\citealt" or "\\citealp"),
+              citation_optargs(cite), "{", cite.name, "}"}
+          end
+          buffer[#buffer + 1] = "}"
+          return buffer
+        else -- A string of simple citations
+          local buffer = {}
+          for i, cite in ipairs(cites) do
+            buffer[#buffer + 1] = {i == 1 and (text_cites and "\\citet{" or
+              "\\citep{") or ", ", cite.name}
+          end
+          buffer[#buffer + 1] = "}"
+          return buffer
+        end
+      end
+    end
+  elseif options.citations == "biblatex" then
+    --- BibLaTeX citations
+    function LaTeX.citations(text_cites, cites)
+      if #cites == 1 then -- A single citation
+        local cite = cites[1]
+        if text_cites then
+          return {"\\textcite", citation_optargs(cite), "{", cite.name, "}"}
+        else
+          return {"\\autocite", cite.suppress_author and "*" or "",
+            citation_optargs(cite), "{", cite.name, "}"}
+        end
+      else -- A string of citations
+        local buffer = {text_cites and "\\textcites" or "\\autocites"}
+        for _, cite in ipairs(cites) do
+          buffer[#buffer + 1] = {citation_optargs(cite), "{", cite.name, "}"}
+        end
+        return buffer
+      end
+    end
   end
 
   function LaTeX.definitionlist(items)

--- a/lunamark/writer/tex.lua
+++ b/lunamark/writer/tex.lua
@@ -29,6 +29,8 @@ function M.new(options)
 
   TeX.ndash = "--"
 
+  TeX.nbsp = "~"
+
   function TeX.singlequoted(s)
     return format("`%s'",s)
   end

--- a/tests/lunamark/citations-biblatex.test
+++ b/tests/lunamark/citations-biblatex.test
@@ -1,0 +1,87 @@
+lunamark -t latex -Xcitations=biblatex
+<<<
+Blah blah [see @doe99, pp. 33-35; also @smith04, chap. 1].
+
+Blah blah [see @doe99,
+pp. 33-35; also @smith04,
+chap. 1].
+
+Blah blah [@doe99, pp. 33-35, 38-39 and *passim*].
+
+Blah blah [@smith04; @doe99].
+
+Smith says blah [-@smith04].
+
+@smith04 says blah.
+
+@smith04 [p. 33] says blah.
+
+[@this; @is; @a; @string; @of; @simple; @no-suppress-author; @bracketed; @citations]
+
+@this [; @is; @a; @string; @of; @simple; @no-suppress-author; @in-text; @citations]
+
+[-@this; -@is; -@a; -@string; -@of; -@simple; -@suppress-author; -@bracketed; -@citations]
+
+-@this [; -@is; -@a; -@string; -@of; -@simple; -@suppress-author; -@in-text; -@citations]
+
+[-@this; @is; -@a; @string; -@of; @simple; -@combined; @bracketed; -@citations]
+
+-@this [; @is; -@a; @string; -@of; @simple; -@combined; @in-text; -@citations]
+
+[@this; is @a; @string of; complex no-suppress-author @bracketed citations]
+
+@this [; is @a; @string of; complex no-suppress-author @in-text citations]
+
+[-@this; is -@a; -@string of; complex suppress-author -@bracketed citations]
+
+-@this [; is -@a; -@string of; complex suppress-author -@in-text citations]
+
+[-@this; is -@a; @string of; complex combined -@bracketed citations]
+
+-@this [; is -@a; @string of; complex combined -@in-text citations]
+
+[@separate] [@bracketed] [@citations]
+
+@separate @in-text @citations
+>>>
+Blah blah \autocites[see][pp.~33-35]{doe99}[also][chap.~1]{smith04}.
+
+Blah blah \autocites[see][pp.~33-35]{doe99}[also][chap.~1]{smith04}.
+
+Blah blah \autocite[pp.~33-35,~38-39~and~\emph{passim}]{doe99}.
+
+Blah blah \autocites{smith04}{doe99}.
+
+Smith says blah \autocite*{smith04}.
+
+\textcite{smith04} says blah.
+
+\textcite[p.~33]{smith04} says blah.
+
+\autocites{this}{is}{a}{string}{of}{simple}{no-suppress-author}{bracketed}{citations}
+
+\textcites{this}{is}{a}{string}{of}{simple}{no-suppress-author}{in-text}{citations}
+
+\autocites{this}{is}{a}{string}{of}{simple}{suppress-author}{bracketed}{citations}
+
+\textcites{this}{is}{a}{string}{of}{simple}{suppress-author}{in-text}{citations}
+
+\autocites{this}{is}{a}{string}{of}{simple}{combined}{bracketed}{citations}
+
+\textcites{this}{is}{a}{string}{of}{simple}{combined}{in-text}{citations}
+
+\autocites{this}[is][]{a}[~of]{string}[complex~no-suppress-author][~citations]{bracketed}
+
+\textcites{this}[is][]{a}[~of]{string}[complex~no-suppress-author][~citations]{in-text}
+
+\autocites{this}[is][]{a}[~of]{string}[complex~suppress-author][~citations]{bracketed}
+
+\textcites{this}[is][]{a}[~of]{string}[complex~suppress-author][~citations]{in-text}
+
+\autocites{this}[is][]{a}[~of]{string}[complex~combined][~citations]{bracketed}
+
+\textcites{this}[is][]{a}[~of]{string}[complex~combined][~citations]{in-text}
+
+\autocite{separate} \autocite{bracketed} \autocite{citations}
+
+\textcite{separate} \textcite{in-text} \textcite{citations}

--- a/tests/lunamark/citations-echo.test
+++ b/tests/lunamark/citations-echo.test
@@ -1,0 +1,87 @@
+lunamark -Xcitations,-citation_nbsps
+<<<
+Blah blah [see @doe99, pp. 33-35; also @smith04, chap. 1].
+
+Blah blah [see @doe99,
+pp. 33-35; also @smith04,
+chap. 1].
+
+Blah blah [@doe99, pp. 33-35, 38-39 and *passim*].
+
+Blah blah [@smith04; @doe99].
+
+Smith says blah [-@smith04].
+
+@smith04 says blah.
+
+@smith04 [p. 33] says blah.
+
+[@this; @is; @a; @string; @of; @simple; @no-suppress-author; @bracketed; @citations]
+
+@this [; @is; @a; @string; @of; @simple; @no-suppress-author; @in-text; @citations]
+
+[-@this; -@is; -@a; -@string; -@of; -@simple; -@suppress-author; -@bracketed; -@citations]
+
+-@this [; -@is; -@a; -@string; -@of; -@simple; -@suppress-author; -@in-text; -@citations]
+
+[-@this; @is; -@a; @string; -@of; @simple; -@combined; @bracketed; -@citations]
+
+-@this [; @is; -@a; @string; -@of; @simple; -@combined; @in-text; -@citations]
+
+[@this; is @a; @string of; complex no-suppress-author @bracketed citations]
+
+@this [; is @a; @string of; complex no-suppress-author @in-text citations]
+
+[-@this; is -@a; -@string of; complex suppress-author -@bracketed citations]
+
+-@this [; is -@a; -@string of; complex suppress-author -@in-text citations]
+
+[-@this; is -@a; @string of; complex combined -@bracketed citations]
+
+-@this [; is -@a; @string of; complex combined -@in-text citations]
+
+[@separate] [@bracketed] [@citations]
+
+@separate @in-text @citations
+>>>
+<p>Blah blah [see @doe99 pp. 33-35; also @smith04 chap. 1].</p>
+
+<p>Blah blah [see @doe99 pp. 33-35; also @smith04 chap. 1].</p>
+
+<p>Blah blah [@doe99 pp. 33-35, 38-39 and <em>passim</em>].</p>
+
+<p>Blah blah [@smith04; @doe99].</p>
+
+<p>Smith says blah [-@smith04].</p>
+
+<p>@smith04 says blah.</p>
+
+<p>@smith04 [p. 33] says blah.</p>
+
+<p>[@this; @is; @a; @string; @of; @simple; @no-suppress-author; @bracketed; @citations]</p>
+
+<p>@this; @is; @a; @string; @of; @simple; @no-suppress-author; @in-text; @citations</p>
+
+<p>[-@this; -@is; -@a; -@string; -@of; -@simple; -@suppress-author; -@bracketed; -@citations]</p>
+
+<p>-@this; -@is; -@a; -@string; -@of; -@simple; -@suppress-author; -@in-text; -@citations</p>
+
+<p>[-@this; @is; -@a; @string; -@of; @simple; -@combined; @bracketed; -@citations]</p>
+
+<p>-@this; @is; -@a; @string; -@of; @simple; -@combined; @in-text; -@citations</p>
+
+<p>[@this; is @a; @string  of; complex no-suppress-author @bracketed  citations]</p>
+
+<p>@this; is @a; @string  of; complex no-suppress-author @in-text  citations</p>
+
+<p>[-@this; is -@a; -@string  of; complex suppress-author -@bracketed  citations]</p>
+
+<p>-@this; is -@a; -@string  of; complex suppress-author -@in-text  citations</p>
+
+<p>[-@this; is -@a; @string  of; complex combined -@bracketed  citations]</p>
+
+<p>-@this; is -@a; @string  of; complex combined -@in-text  citations</p>
+
+<p>[@separate] [@bracketed] [@citations]</p>
+
+<p>@separate @in-text @citations</p>

--- a/tests/lunamark/citations-latex.test
+++ b/tests/lunamark/citations-latex.test
@@ -1,0 +1,87 @@
+lunamark -t latex -Xcitations=latex
+<<<
+Blah blah [see @doe99, pp. 33-35; also @smith04, chap. 1].
+
+Blah blah [see @doe99,
+pp. 33-35; also @smith04,
+chap. 1].
+
+Blah blah [@doe99, pp. 33-35, 38-39 and *passim*].
+
+Blah blah [@smith04; @doe99].
+
+Smith says blah [-@smith04].
+
+@smith04 says blah.
+
+@smith04 [p. 33] says blah.
+
+[@this; @is; @a; @string; @of; @simple; @no-suppress-author; @bracketed; @citations]
+
+@this [; @is; @a; @string; @of; @simple; @no-suppress-author; @in-text; @citations]
+
+[-@this; -@is; -@a; -@string; -@of; -@simple; -@suppress-author; -@bracketed; -@citations]
+
+-@this [; -@is; -@a; -@string; -@of; -@simple; -@suppress-author; -@in-text; -@citations]
+
+[-@this; @is; -@a; @string; -@of; @simple; -@combined; @bracketed; -@citations]
+
+-@this [; @is; -@a; @string; -@of; @simple; -@combined; @in-text; -@citations]
+
+[@this; is @a; @string of; complex no-suppress-author @bracketed citations]
+
+@this [; is @a; @string of; complex no-suppress-author @in-text citations]
+
+[-@this; is -@a; -@string of; complex suppress-author -@bracketed citations]
+
+-@this [; is -@a; -@string of; complex suppress-author -@in-text citations]
+
+[-@this; is -@a; @string of; complex combined -@bracketed citations]
+
+-@this [; is -@a; @string of; complex combined -@in-text citations]
+
+[@separate] [@bracketed] [@citations]
+
+@separate @in-text @citations
+>>>
+Blah blah see~\cite[pp.~33-35]{doe99} also~\cite[chap.~1]{smith04}.
+
+Blah blah see~\cite[pp.~33-35]{doe99} also~\cite[chap.~1]{smith04}.
+
+Blah blah \cite[pp.~33-35,~38-39~and~\emph{passim}]{doe99}.
+
+Blah blah \cite{smith04, doe99}.
+
+Smith says blah \cite{smith04}.
+
+\cite{smith04} says blah.
+
+\cite[p.~33]{smith04} says blah.
+
+\cite{this, is, a, string, of, simple, no-suppress-author, bracketed, citations}
+
+\cite{this, is, a, string, of, simple, no-suppress-author, in-text, citations}
+
+\cite{this, is, a, string, of, simple, suppress-author, bracketed, citations}
+
+\cite{this, is, a, string, of, simple, suppress-author, in-text, citations}
+
+\cite{this, is, a, string, of, simple, combined, bracketed, citations}
+
+\cite{this, is, a, string, of, simple, combined, in-text, citations}
+
+\cite{this} is~\cite{a} \cite[~of]{string} complex~no-suppress-author~\cite[~citations]{bracketed}
+
+\cite{this} is~\cite{a} \cite[~of]{string} complex~no-suppress-author~\cite[~citations]{in-text}
+
+\cite{this} is~\cite{a} \cite[~of]{string} complex~suppress-author~\cite[~citations]{bracketed}
+
+\cite{this} is~\cite{a} \cite[~of]{string} complex~suppress-author~\cite[~citations]{in-text}
+
+\cite{this} is~\cite{a} \cite[~of]{string} complex~combined~\cite[~citations]{bracketed}
+
+\cite{this} is~\cite{a} \cite[~of]{string} complex~combined~\cite[~citations]{in-text}
+
+\cite{separate} \cite{bracketed} \cite{citations}
+
+\cite{separate} \cite{in-text} \cite{citations}

--- a/tests/lunamark/citations-natbib.test
+++ b/tests/lunamark/citations-natbib.test
@@ -1,0 +1,87 @@
+lunamark -t latex -Xcitations=natbib
+<<<
+Blah blah [see @doe99, pp. 33-35; also @smith04, chap. 1].
+
+Blah blah [see @doe99,
+pp. 33-35; also @smith04,
+chap. 1].
+
+Blah blah [@doe99, pp. 33-35, 38-39 and *passim*].
+
+Blah blah [@smith04; @doe99].
+
+Smith says blah [-@smith04].
+
+@smith04 says blah.
+
+@smith04 [p. 33] says blah.
+
+[@this; @is; @a; @string; @of; @simple; @no-suppress-author; @bracketed; @citations]
+
+@this [; @is; @a; @string; @of; @simple; @no-suppress-author; @in-text; @citations]
+
+[-@this; -@is; -@a; -@string; -@of; -@simple; -@suppress-author; -@bracketed; -@citations]
+
+-@this [; -@is; -@a; -@string; -@of; -@simple; -@suppress-author; -@in-text; -@citations]
+
+[-@this; @is; -@a; @string; -@of; @simple; -@combined; @bracketed; -@citations]
+
+-@this [; @is; -@a; @string; -@of; @simple; -@combined; @in-text; -@citations]
+
+[@this; is @a; @string of; complex no-suppress-author @bracketed citations]
+
+@this [; is @a; @string of; complex no-suppress-author @in-text citations]
+
+[-@this; is -@a; -@string of; complex suppress-author -@bracketed citations]
+
+-@this [; is -@a; -@string of; complex suppress-author -@in-text citations]
+
+[-@this; is -@a; @string of; complex combined -@bracketed citations]
+
+-@this [; is -@a; @string of; complex combined -@in-text citations]
+
+[@separate] [@bracketed] [@citations]
+
+@separate @in-text @citations
+>>>
+Blah blah \citetext{\citealp[see][pp.~33-35]{doe99}; \citealp[also][chap.~1]{smith04}}.
+
+Blah blah \citetext{\citealp[see][pp.~33-35]{doe99}; \citealp[also][chap.~1]{smith04}}.
+
+Blah blah \citep[pp.~33-35,~38-39~and~\emph{passim}]{doe99}.
+
+Blah blah \citep{smith04, doe99}.
+
+Smith says blah \citeyearpar{smith04}.
+
+\citet{smith04} says blah.
+
+\citet[p.~33]{smith04} says blah.
+
+\citep{this, is, a, string, of, simple, no-suppress-author, bracketed, citations}
+
+\citet{this, is, a, string, of, simple, no-suppress-author, in-text, citations}
+
+\citetext{\citeyear{this}; \citeyear{is}; \citeyear{a}; \citeyear{string}; \citeyear{of}; \citeyear{simple}; \citeyear{suppress-author}; \citeyear{bracketed}; \citeyear{citations}}
+
+\citetext{\citeyear{this}; \citeyear{is}; \citeyear{a}; \citeyear{string}; \citeyear{of}; \citeyear{simple}; \citeyear{suppress-author}; \citeyear{in-text}; \citeyear{citations}}
+
+\citetext{\citeyear{this}; \citealp{is}; \citeyear{a}; \citealp{string}; \citeyear{of}; \citealp{simple}; \citeyear{combined}; \citealp{bracketed}; \citeyear{citations}}
+
+\citetext{\citeyear{this}; \citealt{is}; \citeyear{a}; \citealt{string}; \citeyear{of}; \citealt{simple}; \citeyear{combined}; \citealt{in-text}; \citeyear{citations}}
+
+\citetext{\citealp{this}; \citealp[is][]{a}; \citealp[~of]{string}; \citealp[complex~no-suppress-author][~citations]{bracketed}}
+
+\citetext{\citealt{this}; \citealt[is][]{a}; \citealt[~of]{string}; \citealt[complex~no-suppress-author][~citations]{in-text}}
+
+\citetext{\citeyear{this}; \citeyear[is][]{a}; \citeyear[~of]{string}; \citeyear[complex~suppress-author][~citations]{bracketed}}
+
+\citetext{\citeyear{this}; \citeyear[is][]{a}; \citeyear[~of]{string}; \citeyear[complex~suppress-author][~citations]{in-text}}
+
+\citetext{\citeyear{this}; \citeyear[is][]{a}; \citealp[~of]{string}; \citeyear[complex~combined][~citations]{bracketed}}
+
+\citetext{\citeyear{this}; \citeyear[is][]{a}; \citealt[~of]{string}; \citeyear[complex~combined][~citations]{in-text}}
+
+\citep{separate} \citep{bracketed} \citep{citations}
+
+\citet{separate} \citet{in-text} \citet{citations}


### PR DESCRIPTION
This commit adds support for Pandoc-style citations as discussed in #19.

```bash
$ lunamark -Xcitations=biblatex -t latex
Smith says blah [-@smith04].
Smith says blah \autocite*{smith04}.
```

The LaTeX writer produces either vanilla LaTeX2e, Natbib, or BibLaTeX output;
the Natbib and BibLaTeX output has been modelled after the output of Pandoc.
The shell interface has been extended, so that the user can specify either
`-citations`, `+citations`, or `citations=[latex|natbib|biblatex]`.

Non-LaTeX writers echo the original citations back. These are normalized, since
the information about the precise input syntax is lost during tokenization.

Unlike in Pandoc, there is no detection of locator terms. Therefore, an
(implicitly enabled) option of `citation_nbsps` has been added that replaces
all spacing inside the citation pre- and post-fixes with non-breaking spaces.
Non-breaking spaces were added to writers, so they are available for future use.

The citation syntax is a superset of the syntax understood by Pandoc (1.17.2),
since it recognizes `@cite1 [; @cite2; @cite3]` as a string of three in-text
citations, whereas Pandoc recognizes the input as an in-text citation followed
by a string of two bracketed citations, the first of which is prefixed with a
semicolon.