### PR TITLE
Unordered list items now may begin with a bulletchar.

### DIFF
--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -284,7 +284,7 @@ function M.new(writer, options)
                      + space * bulletchar * #spacing * (tab + space^-2)
                      + space * space * bulletchar * #spacing * (tab + space^-1)
                      + space * space * space * bulletchar * #spacing
-                     ) * -bulletchar
+                     )
 
   local dig
   if options.hash_enumerators then


### PR DESCRIPTION
I have discovered an issue in the handling of unordered lists. The following
input:

```
This is a bullet list:

 - bullet one
 - *bullet two*
 - -bullet three
```

translates to:

```
<p>This is a bullet list:</p>

<ul>
<li>bullet one - <em>bullet two</em> - -bullet three</li>
</ul>
```

instead of the expected:

```
<p>This is a bullet list:</p>

<ul>
<li>bullet one</li>
<li><em>bullet two</em></li>
<li>-bullet three</li>
</ul>
```

The core of the issue seems to be the closing `-bulletchar` in the `bullet`
pattern:

```
local bullet = ( Cg(bulletchar, "bulletchar") * #spacing * (tab + space^-3)
               + space * Cg(bulletchar, "bulletchar") * #spacing * (tab + space^-2)
               + space * space * Cg(bulletchar, "bulletchar") * #spacing * (tab + space^-1)
               + space * space * space * Cg(bulletchar, "bulletchar") * #spacing
               ) * -bulletchar
```

It is not there to prevent the misparsing of horizontal rules (these are
explicitly handled by `TightListItem` and `LooseListItem`) or strong emphasis
(since list items indicate block structure and therefore take precedence).
I removed it and now all seems to work.
