### PR TITLE
Added support for Pandoc-style inline footnotes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -36,7 +36,7 @@ Lunamark's markdown parser currently supports a number of extensions
 
   - Smart typography (fancy quotes, dashes, ellipses)
   - Significant start numbers in ordered lists
-  - Footnotes
+  - Footnotes (both regular and inline)
   - Definition lists
   - Pandoc-style title blocks
   - Pandoc-style citations

--- a/bin/lunamark
+++ b/bin/lunamark
@@ -24,7 +24,7 @@ can be turned on or off individually):
 
   - Smart typography (fancy quotes, dashes, ellipses)
   - Significant start numbers in ordered lists
-  - Footnotes
+  - Footnotes (both regular and inline)
   - Definition lists
   - Metadata
   - Pandoc title blocks
@@ -120,6 +120,14 @@ environment variable `LUNAMARK_EXTENSIONS` (see ENVIRONMENT below).
         [^mynote]: This note has two paragraphs.
 
             Here is the second one.
+
+`(-) inline_notes`
+:   Inline footnotes. An inline footnote is like a markdown bracketed
+    reference, but preceded with a circumflex (`^`). Example:
+
+        Here is an inline note.^[Inlines notes are easier to write,
+        since you don't have to pick an identifier and move down to
+        type the note.]
 
 `(-) definition_lists`
 :   Definition lists.  A list item consists of a term, on a single
@@ -371,6 +379,7 @@ given in parentheses:
   (-) smart                Smart typography (quotes, dashes, ellipses)
   (-) preserve_tabs        Don't expand tabs to spaces
   (-) notes                Footnotes
+  (-) inline_notes         Inline footnotes
   (-) definition_lists     Definition lists
   (-) citations            Citations
   (+) citation_nbsps       Turn spacing into non-breaking spaces in citations
@@ -426,6 +435,7 @@ local extensions = {  -- defaults
   smart = false,
   preserve_tabs = false,
   notes = false,
+  inline_notes = false,
   citations = false,
   citation_nbsps = true,
   definition_lists = false,

--- a/tests/lunamark/inline_notes.test
+++ b/tests/lunamark/inline_notes.test
@@ -1,0 +1,21 @@
+lunamark -Xinline_notes,notes
+<<<
+Here is an inline note.^[Inlines notes are easier to write, since
+you don't have to pick an identifier and move down to type the 
+note.]
+
+Here is a footnote reference.[^1]
+
+[^1]: Here is the footnote.
+>>>
+<p>Here is an inline note.<sup><a href="#fn1" class="footnoteRef" id="fnref1">1</a></sup></p>
+
+<p>Here is a footnote reference.<sup><a href="#fn2" class="footnoteRef" id="fnref2">2</a></sup></p>
+
+<hr />
+
+<ol class="notes">
+<li id="fn1">Inlines notes are easier to write, since you don&#39;t have to pick an identifier and move down to type the note. <a href="#fnref1" class="footnoteBackLink">↩</a></li>
+
+<li id="fn2"><p>Here is the footnote. <a href="#fnref2" class="footnoteBackLink">↩</a></p></li>
+</ol>


### PR DESCRIPTION
This commit adds support for [Pandoc-style inline footnotes](http://pandoc.org/MANUAL.html#extension-inline_notes).

```html
$ lunamark -Xinline_notes <<< 'Here is an inline note.^[Inline notes are easier to write.]'
<p>Here is an inline note.<sup><a href="#fn1" class="footnoteRef" id="fnref1">1</a></sup></p>

<hr />

<ol class="notes">
<li id="fn1">Inline notes are easier to write. <a href="#fnref1" class="footnoteBackLink">↩</a></li>
</ol>
```

We are still hitting the upper limit of 200 local variables in the `M.new` method from `lunamark/reader/markdown.lua`. For now, I have moved a couple more parsers outside the function. In the future, it will be necessary to refactor the library, so that parsers are stored in one or several (possibly static) hash tables.