### PR TITLE
Moved the parsers into a hash table

### DIFF
--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -1167,7 +1167,7 @@ function M.new(writer, options)
   -- Syntax specification
   ------------------------------------------------------------------------------
 
-  larsers.syntax =
+  syntax =
     { "Blocks",
 
       Blocks                = Blank^0 * Block^-1
@@ -1243,36 +1243,36 @@ function M.new(writer, options)
     }
 
   if not options.definition_lists then
-    larsers.syntax.DefinitionList = parsers.fail
+    syntax.DefinitionList = parsers.fail
   end
 
   if not options.fenced_code_blocks then
-    larsers.syntax.FencedCodeBlock = parsers.fail
+    syntax.FencedCodeBlock = parsers.fail
   end
 
   if not options.citations then
-    larsers.syntax.Citations = parsers.fail
+    syntax.Citations = parsers.fail
   end
 
   if not options.notes then
-    larsers.syntax.NoteRef = parsers.fail
+    syntax.NoteRef = parsers.fail
   end
 
   if not options.inline_notes then
-    larsers.syntax.InlineNote = parsers.fail
+    syntax.InlineNote = parsers.fail
   end
 
   if not options.smart then
-    larsers.syntax.Smart = parsers.fail
+    syntax.Smart = parsers.fail
   end
 
   if options.alter_syntax and type(options.alter_syntax) == "function" then
-    larsers.syntax = options.alter_syntax(larsers.syntax)
+    syntax = options.alter_syntax(syntax)
   end
 
-  larsers.blocks = Ct(larsers.syntax)
+  larsers.blocks = Ct(syntax)
 
-  local inlines_t = util.table_copy(larsers.syntax)
+  local inlines_t = util.table_copy(syntax)
   inlines_t[1] = "Inlines"
   inlines_t.Inlines = Inline^0 * (parsers.spacing^0 * parsers.eof / "")
   larsers.inlines = Ct(inlines_t)

--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -1114,7 +1114,7 @@ function M.new(writer, options)
                            ) / writer.definitionlist
 
   ------------------------------------------------------------------------------
-  -- Lua metadata
+  -- Lua metadata (local)
   ------------------------------------------------------------------------------
 
   local function lua_metadata(s)  -- run lua code in comment in sandbox
@@ -1134,9 +1134,10 @@ function M.new(writer, options)
     return ""
   end
 
-  local LuaMeta = parsers.fail
   if options.lua_metadata then
-    LuaMeta = #P("<!--@") * parsers.htmlcomment / lua_metadata
+    larsers.LuaMeta = #P("<!--@") * parsers.htmlcomment / lua_metadata
+  else
+    larsers.LuaMeta = parsers.fail
   end
 
   ------------------------------------------------------------------------------
@@ -1171,7 +1172,7 @@ function M.new(writer, options)
   ------------------------------------------------------------------------------
 
   local Blank          = parsers.blankline / ""
-                       + LuaMeta
+                       + larsers.LuaMeta
                        + larsers.NoteBlock
                        + larsers.Reference
                        + (parsers.tightblocksep / "\n")

--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -455,6 +455,17 @@ parsers.inlinehtml  = parsers.emptyelt_any
                     + parsers.openelt_any
                     + parsers.closeelt_any
 
+------------------------------------------------------------------------------
+-- Parsers used for HTML entities
+------------------------------------------------------------------------------
+
+parsers.hexentity = parsers.ampersand * parsers.hash * S("Xx")
+                  * C(parsers.hexdigit^1) * parsers.semicolon
+parsers.decentity = parsers.ampersand * parsers.hash
+                  * C(parsers.digit^1) * parsers.semicolon
+parsers.tagentity = parsers.ampersand * C(parsers.alphanumeric^1)
+                  * parsers.semicolon
+
 --- Create a new markdown parser.
 --
 -- *   `writer` is a writer table (see [lunamark.writer.generic]).
@@ -750,17 +761,6 @@ function M.new(writer, options)
   end
 
   ------------------------------------------------------------------------------
-  -- Entities
-  ------------------------------------------------------------------------------
-
-  local hexentity = parsers.ampersand * parsers.hash * S("Xx")
-                  * C(parsers.hexdigit^1) * parsers.semicolon
-  local decentity = parsers.ampersand * parsers.hash
-                  * C(parsers.digit^1) * parsers.semicolon
-  local tagentity = parsers.ampersand * C(parsers.alphanumeric^1)
-                  * parsers.semicolon
-
-  ------------------------------------------------------------------------------
   -- Inline elements
   ------------------------------------------------------------------------------
 
@@ -923,9 +923,9 @@ function M.new(writer, options)
 
   local InlineHtml    = C(parsers.inlinehtml) / writer.inline_html
 
-  local HtmlEntity    = hexentity / entities.hex_entity  / writer.string
-                      + decentity / entities.dec_entity  / writer.string
-                      + tagentity / entities.char_entity / writer.string
+  local HtmlEntity    = parsers.hexentity / entities.hex_entity  / writer.string
+                      + parsers.decentity / entities.dec_entity  / writer.string
+                      + parsers.tagentity / entities.char_entity / writer.string
 
   ------------------------------------------------------------------------------
   -- Block elements


### PR DESCRIPTION
This series of commits moves parsers into a separate hash table as
discussed in #24. The average CPU time in seconds measured by
`make bench` (500 samples) went up from 0.617380 to 0.632300.
This is likely due to the hash table access overhead as you predicted.