### PR TITLE
lunamark/reader/markdown.lua:1311: *** global SET of syntax

### DIFF
--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -1233,7 +1233,7 @@ function M.new(writer, options)
   -- Syntax specification
   ------------------------------------------------------------------------------
 
-  syntax =
+  local syntax =
     { "Blocks",
 
       Blocks                = larsers.Blank^0 * parsers.Block^-1


### PR DESCRIPTION
The `syntax` variable was declared as global in the pull request #25.
This commit fixes the issue. No other issues are reported by lualint.