### PR TITLE
Fixed blockquote parsing

### DIFF
--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -1050,7 +1050,8 @@ function M.new(writer, options)
   -- strip off leading > and indents, and run through blocks
   larsers.Blockquote  = Cs((((parsers.leader * parsers.more * parsers.space^-1)/""
                              * parsers.linechar^0 * parsers.newline)^1
-                            * (-parsers.blankline * parsers.linechar^1
+                            * (-(parsers.leader * parsers.more
+                                + parsers.blankline) * parsers.linechar^1
                               * parsers.newline)^0 * parsers.blankline^0
                            )^1) / parse_blocks / writer.blockquote
 

--- a/tests/lunamark/lazy_blockquotes.test
+++ b/tests/lunamark/lazy_blockquotes.test
@@ -1,0 +1,9 @@
+lunamark
+<<<
+> bar
+baz
+> foo
+>>>
+<blockquote>
+<p>bar baz foo</p>
+</blockquote>


### PR DESCRIPTION
This patch fixes a bug in the parsing of blockquotes. This is the
expected behavior (as per [example 194](http://spec.commonmark.org/0.27/#example-194) of CommonMark):

```
$ markdown_py
> bar
baz
> foo

<blockquote>
<p>bar
baz
foo</p>
</blockquote>
```

This is the Lunamark behavior prior to the patch:

```
$ bin/lunamark 
> bar
baz
> foo

<blockquote>
<p>bar baz</p>

<blockquote>
<p>foo</p>
</blockquote>
</blockquote>
```

This is the Lunamark behavior after the patch:

```
$ bin/lunamark 
> bar
baz
> foo

<blockquote>
<p>bar baz foo</p>
</blockquote>
```