### PR TITLE
Cast start number of ordered list item to integer in Lua 5.3

### DIFF
--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -1126,6 +1126,9 @@ function M.new(writer, options)
   local function ordered_list(s,tight,startnum)
     if options.startnum then
       startnum = tonumber(startnum) or 1  -- fallback for '#'
+      if startnum ~= nil then
+        startnum = math.floor(startnum)
+      end
     else
       startnum = nil
     end


### PR DESCRIPTION
In Lua 5.2, both `print(4)` and `print(4.0)` writes out `4`, since both numbers are internally represented as floats. Since version 5.3, Lua differentiates between floats and integers, which affects how casting numbers to strings behaves. Now, `print(4)` writes out `4`, whereas `print(4.0)` writes out `4.0`.

The code seems to be mostly immune to this change, since we rarely work with numbers, but I discovered one minor regression. Since `larsers.enumerator` captures both the number and the period, the `tonumber` function casts the string to a float rather than an integer, affecting the conversion output.