### PR TITLE
feat: Support header_attributes extension

### DIFF
--- a/bin/lunamark
+++ b/bin/lunamark
@@ -355,6 +355,10 @@ environment variable `LUNAMARK_EXTENSIONS` (see ENVIRONMENT below).
 :   Enable the Pandoc `table_captions` syntax extension for
     tables.
 
+`(-) header_attributes`
+:   Headings can be assigned attributes at the end of the line containing
+    the heading text.
+
 # TEMPLATES
 
 By default, lunamark will produce a fragment.  If the
@@ -505,6 +509,7 @@ given in parentheses:
   (-) link_attributes      Link attributes
   (-) pipe_tables          PHP Markdown Extra pipe table support
   (-) table_captions       Table caption syntax extension
+  (-) header_attributes    Header attributes
 The keyword 'all' may also be used, to set all extensions simultaneously.
 Setting the environment variable LUNAMARK_EXTENSIONS can change the
 defaults.
@@ -573,6 +578,7 @@ local extensions = {  -- defaults
   link_attributes = false,
   pipe_tables = false,
   table_captions = false,
+  header_attributes = false,
 }
 
 if optarg["0"] then

--- a/lunamark/writer/generic.lua
+++ b/lunamark/writer/generic.lua
@@ -244,8 +244,8 @@ function M.new(options)
     return s
   end
 
-  --- Header level `level`, with text `s`.
-  function W.header(s)
+  --- Header with text `s`, level `level` and optional attributes `attr`
+  function W.header(s, _, _)
     return s
   end
 

--- a/lunamark/writer/html.lua
+++ b/lunamark/writer/html.lua
@@ -178,7 +178,10 @@ function M.new(options)
     return format == "html" and s or {}
   end
 
-  function Html.header(s,level)
+  function Html.header(s,level,attr)
+    local class = attr.class and attr.class ~= "" and ' class="'..attr.class..'"' or ""
+    local id = attr.id and ' id="'..attr.id..'"' or ""
+    local lang = attr.lang and ' lang="'..attr.lang..'"' or ""
     local sep = ""
     if options.slides or options.containers then
       local lev = (options.slides and 1) or level
@@ -188,7 +191,7 @@ function M.new(options)
       end
       sep = stop .. Html.start_section(lev) .. Html.containersep
     end
-    return {sep, "<h", level, ">", s, "</h", level, ">"}
+    return {sep, "<h", level, id, class, lang, ">", s, "</h", level, ">"}
   end
 
   Html.hrule = "<hr />"

--- a/tests/lunamark/ext_header_attributes.test
+++ b/tests/lunamark/ext_header_attributes.test
@@ -1,0 +1,12 @@
+lunamark -Xheader_attributes
+<<<
+# Header1 {-}
+
+## Sous-section { #header-2 .myclass lang=fr }
+
+Setext { #header-3 .otherclass lang=en }
+------
+>>>
+<h1 class="unnumbered">Header1</h1>
+<h2 id="header-2" class="myclass" lang="fr">Sous-section</h2>
+<h2 id="header-3" class="otherclass" lang="en">Setext</h2>


### PR DESCRIPTION
This PR adds the `header_attributes` option on ATX and Setext headers, i.e. `{ #id .class .class ... key=value }` support at the end of the header line, with `-` also understood as `.unnumbered` in "class" position.

(N.B. Unless mistaken, `witiko/markdown` already has something to that extent, though implementation likely differs. Here I just reused and expanded the attribute support used in other commands such as Spans, Divs, etc.)