### PR TITLE
feat: Support line_blocks extension

### DIFF
--- a/bin/lunamark
+++ b/bin/lunamark
@@ -359,6 +359,19 @@ environment variable `LUNAMARK_EXTENSIONS` (see ENVIRONMENT below).
 :   Headings can be assigned attributes at the end of the line containing
     the heading text.
 
+`(-) line_blocks`
+:   A line block is a sequence of lines beginning with a vertical bar
+    followed by a space. The division into lines will be preserved in the
+    output, as will any leading spaces; otherwise, the lines will be
+    formatted as Markdown.
+
+    Inline formatting (such as emphasis) is allowed
+    in the content, but not block-level formatting (such as block quotes or
+    lists).
+
+    The lines can be hard-wrapped if needed, but the continuation line must
+    begin with a space.
+
 # TEMPLATES
 
 By default, lunamark will produce a fragment.  If the
@@ -510,6 +523,7 @@ given in parentheses:
   (-) pipe_tables          PHP Markdown Extra pipe table support
   (-) table_captions       Table caption syntax extension
   (-) header_attributes    Header attributes
+  (-) line_blocks          Line blocks
 The keyword 'all' may also be used, to set all extensions simultaneously.
 Setting the environment variable LUNAMARK_EXTENSIONS can change the
 defaults.
@@ -579,6 +593,7 @@ local extensions = {  -- defaults
   pipe_tables = false,
   table_captions = false,
   header_attributes = false,
+  line_blocks = false,
 }
 
 if optarg["0"] then

--- a/lunamark/writer/generic.lua
+++ b/lunamark/writer/generic.lua
@@ -351,6 +351,18 @@ function M.new(options)
     return ""
   end
 
+  --- A line block.
+  -- For each line, the leading spaces in the first inline are changed
+  -- into nbsp (U+00A0) as with Pandoc.
+  function W.lineblock(lines)
+    local t = {}
+    for i = 1, #lines - 1 do
+      t[#t + 1] = { lines[i], "\n" }
+    end
+    t[#t + 1] = lines[#lines]
+    return t
+  end
+
   --- A cosmo template to be used in producing a standalone document.
   -- `$body` is replaced with the document body, `$title` with the
   -- title, and so on.

--- a/lunamark/writer/html.lua
+++ b/lunamark/writer/html.lua
@@ -284,6 +284,17 @@ function M.new(options)
     return { "<table>\n", t, "</table>\n" }
   end
 
+  function Html.lineblock(lines)
+    local t = {}
+
+    for i = 1, #lines - 1 do
+      t[#t + 1] = { lines[i], "<br />\n"}
+    end
+    t[#t + 1] = { lines[#lines] }
+
+    return { '<div class="line-block">', t, "</div>" }
+  end
+
   Html.template = [[
 <html>
 <head>

--- a/tests/lunamark/ext_line_blocks.test
+++ b/tests/lunamark/ext_line_blocks.test
@@ -1,0 +1,31 @@
+lunamark -Xline_blocks
+<<<
+Line blocks
+
+| The _limerick_ packs laughs anatomical
+| In space that is quite economical.
+|    But the **good** ones I have seen
+|        So seldom are clean
+| And the clean ones so seldom are comical
+
+Line blocks with continuation
+
+| The Right Honorable Most Venerable and Righteous Samuel L.
+  Constable, Jr.
+| 200 Main St.
+| Berkeley,
+ CA 94718
+>>>
+<p>Line blocks</p>
+
+<div class="line-block">The <em>limerick</em> packs laughs anatomical<br />
+In space that is quite economical.<br />
+   But the <strong>good</strong> ones I have seen<br />
+       So seldom are clean<br />
+And the clean ones so seldom are comical</div>
+
+<p>Line blocks with continuation</p>
+
+<div class="line-block">The Right Honorable Most Venerable and Righteous Samuel L. Constable, Jr.<br />
+200 Main St.<br />
+Berkeley, CA 94718</div>


### PR DESCRIPTION
Line blocks (for poetry, addresses, etc.) as with Pandoc's `line_blocks` extension (from reStructuredText).

As with Pandoc, the leading spaces (in the first inline element) are turned into non-breakable space (a.k.a. nbsp).

EDIT: As an illustration of my intended use with SILE (still experimenting, but you can get the grasp of it)

![image](https://user-images.githubusercontent.com/18075640/200202829-b98bc854-8c35-4333-8228-f6336fd800b3.png)

@Witiko If you ever consider porting this to your LaTeX package, I'd actually be interested on how you'd achieve such things (stanzas, verse numbering, etc.), as maybe there'd be better / more portable ways.
