### PR TITLE
refactor: fenced divs can be nested

### DIFF
--- a/tests/lunamark/ext_fenced_divs.test
+++ b/tests/lunamark/ext_fenced_divs.test
@@ -7,6 +7,18 @@ Some Div
 ::: {.myclass lang=fr}
 Some better Div
 :::
+
+::: {.level1}
+Fenced Divs can be nested
+
+:::: {.level2}
+This is a nested Div
+::::
+:::
 >>>
 <div>Some Div</div>
 <div class="myclass" lang="fr">Some better Div</div>
+<div class="level1">
+<p>Fenced Divs can be nested</p>
+<div class="level2">This is a nested Div</div>
+</div>


### PR DESCRIPTION
Closes #44

This repairs fenced divs nesting - I marked it as a "refactor" since 0.6.0 is not yet released, but I know there are various schools here, some would go for a "fix" anyhow...

This being said, this is more tricky than I thought... (Extended-)Markdown looks simple on the surface but is plenty of traps!
All our fenced blocks (i.e. tilde fenced code, backtick fenced code and colon fenced divs) currently use the same fencehead/fenceline/fencetail logic, and parse an "infostring" which will later be parsed as an attribute string. This seems pretty generic, but...

- Regarding the fenced div nesting issue...
  - For fenced code blocks, the closing fence must be at least as long as the opening fence (this is covered in the existing test)
  - For fenced divs however, my interpretation is that the closing fence must match the opening fence, since divs of increasing fence length can be nested.
  - **This is what I have fixed here**

- Regarding the infostring...
  - The existing tests for fenced code blocks have a test for "Info strings for backtick code blocks cannot contain backticks"
  - But as implemented (in the common infostring rule), it applies to all cases. Implying:
    - It applies to tilde fence code too. This might be wrong, see e.g. https://github.com/commonmark/commonmark-java/commit/62d5f1068fa3084a0f3757f54658e24336c6bd84, though it's a kind of an edge case... And an old unseen issue likely! To be clear, it means the following doesn't parse as a fenced code block (though it does in Pandoc):
      ```
      ~~~ info`
      Code
      ~~~
      ```
    - It applies to backtick/tilde code blocks and fenced divs with attributes, meaning, if I got that right, that one can't have a backtick in the `{ #id .class key="value" }` construct. This might perhaps be wrong, but it seems a rare edge case too (having a backtick in an identifier, a class or key value doesn't seem very useful anyway, does it?)
    - **I haven't tried to fix that here**: Whatever the standard or common interpretation say, I am not sure it's worth fixing (at the cost of loosing the current generic of fencehead/fenceline/fencetail and replacing them by very similar but slightly different methods for all cases. --> _Perhaps we should open a dedicated issue if it is however felt problematic?_

- Regarding paragraphing in fenced divs
  ```
  :::
  Line
  :::
  ```
  Generates `<div>Line</div>` while Pandoc gets `<div><p>Line</p></div>` -- **I haven't fixed that either here** --> _Perhaps worth an issue?_ (A work-around is to insert a blank line before the closing div fence)
  