### PR TITLE
Include tildes and backticks in infostrings of tilde code blocks

### DIFF
--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -230,14 +230,14 @@ end
 
 parsers.tilde_infostring
                     = C((parsers.linechar
-                       - ((parsers.spacechar + parsers.backtick + parsers.tilde)^1
-                         * parsers.newline))^0)
-                    * (parsers.spacechar + parsers.backtick + parsers.tilde)^0
+                       - (parsers.spacechar^1 * parsers.newline))^0)
+                    * parsers.optionalspace
                     * (parsers.newline + parsers.eof)
 
 parsers.backtick_infostring
-                    = C((parsers.linechar - (parsers.backtick
-                       + parsers.spacechar^1 * parsers.newline))^0)
+                    = C((parsers.linechar
+                       - (parsers.backtick
+                         + parsers.spacechar^1 * parsers.newline))^0)
                     * parsers.optionalspace
                     * (parsers.newline + parsers.eof)
 


### PR DESCRIPTION
Although #55 [fixed the HTML output][1] of tilde code blocks with tildes and backticks in infostrings, it did so by removing tildes and backticks from the infostring. However, this is unnecessary, since the HTML writer will ignore all but the first word of the infostring. This pull request simplifies the parsing by putting tildes and backticks back into the infostrings.

 [1]: https://github.com/jgm/lunamark/pull/55/files#diff-bc48b74255d8cf8ee303bdad9d0b7048e892d4c1ecab3ac3b585eb07dedddaf4