### PR TITLE
feat: Support `mark` (highlight) extension

### DIFF
--- a/bin/lunamark
+++ b/bin/lunamark
@@ -281,6 +281,10 @@ environment variable `LUNAMARK_EXTENSIONS` (see ENVIRONMENT below).
 :   Enable strike-through support for a text enclosed within double
     tildes, as in `~~deleted~~`.
 
+`(-) mark`
+:   Enable highlighting support for a text enclosed within double
+    equals, as in `==marked==`.
+
 `(-) subscript`
 :   Enable superscript support. Superscripts may be written by surrounding
     the subscripted text by `~` characters, as in `2~10~`.
@@ -519,6 +523,7 @@ given in parentheses:
   (-) fancy_lists          Pandoc style fancy lists
   (-) task_list            GitHub-Flavored Markdown task list
   (-) strikeout            Strike-through with double tildes
+  (-) mark                 Highlight with double equals
   (-) subscript            Subscripted text between tildes
   (-) superscript          Superscripted text between circumflexes
   (-) bracketed_spans      Spans with attributes
@@ -590,6 +595,7 @@ local extensions = {  -- defaults
   fancy_lists = false,
   task_list = false,
   strikeout = false,
+  mark = false,
   subscript = false,
   superscript = false,
   bracketed_spans = false,

--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -1203,12 +1203,11 @@ function M.new(writer, options)
                                    parsers.doubletildes)
                    ) / writer.strikeout
 
-  larsers.Mark
-                 = ( parsers.between(parsers.Inline, parsers.doubleequals,
-                                   parsers.doubleequals)
-                   ) / function (inlines)
-                        return writer.span(inlines, { class="mark" })
-                       end
+  larsers.Mark = parsers.between(parsers.Inline, parsers.doubleequals,
+                                 parsers.doubleequals)
+               / function (inlines)
+                   return writer.span(inlines, { class="mark" })
+                 end
 
   larsers.Span   = ( parsers.between(parsers.Inline, parsers.lbracket,
                                    parsers.rbracket) ) * ( parsers.attributes )

--- a/lunamark/writer/html5.lua
+++ b/lunamark/writer/html5.lua
@@ -16,6 +16,8 @@ function M.new(options)
   options = options or {}
   local Html5 = html.new(options)
 
+  local htmlSpan = Html5.span -- inherited, for overriding
+
   Html5.container = "section"
 
   Html5.template = [[
@@ -34,6 +36,14 @@ $body
   function Html5.strikeout(s)
     -- HTML5 obsoletes <strike> and recommends <del>
     return {"<del>", s, "</del>"}
+  end
+
+  function Html5.span(s, attr)
+    -- HTML5 has semantic <mark>
+    if attr.class == "mark" then
+      return {"<mark>", s, "</mark>"}
+    end
+    return htmlSpan(s, attr)
   end
 
   return Html5

--- a/tests/lunamark/ext_mark.test
+++ b/tests/lunamark/ext_mark.test
@@ -1,0 +1,5 @@
+lunamark -Xmark
+<<<
+Some ==highlighted text==.
+>>>
+<p>Some <span class="mark">highlighted text</span>.</p>


### PR DESCRIPTION
The extension is disabled by default.
When enabled, `==marked==` is expanded to a span with class "mark", for parity with upcoming Pandoc, and also Djot's `{=marked=}`.

Closes #65 