### PR TITLE
fix: Pandoc-like attributes are too restrictive

### DIFF
--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -164,7 +164,7 @@ parsers.attrvalue   = (parsers.dquote
                       * parsers.squote)
                     + C((parsers.anyescaped - parsers.dquote - parsers.space - P("}"))^1)
 
-parsers.attrpair    = Cg(C((parsers.attrid)^1)
+parsers.attrpair    = Cg(C(parsers.attrid)
                       * parsers.optionalspace * parsers.equal * parsers.optionalspace
                       * parsers.attrvalue)
                       * parsers.optionalspace^-1

--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -150,21 +150,30 @@ parsers.indented_blocks = function(bl)
 end
 
 -- Attributes list as in Pandoc {#id .class .class-other key=value key2="value 2"}
-parsers.identifier  = parsers.letter
-                      * (parsers.alphanumeric + S("_-"))^0
-parsers.attrvalue   = (parsers.dquote * C((parsers.alphanumeric + S("._- "))^1) * parsers.dquote)
-                      + C((parsers.alphanumeric + S("._-"))^1)
+--   Note: Pandoc has the same identifier definitions, but its interpretation
+--   of a letter (and by extension an alphanumeric value) extends to alphabetic
+--   *Unicode* characters.
+parsers.attrid      = parsers.letter
+                      * (parsers.alphanumeric + S("_-:."))^0
 
-parsers.attrpair    = Cg(C((parsers.identifier)^1)
+parsers.attrvalue   = (parsers.dquote
+                      * C((parsers.anyescaped - parsers.dquote)^0)
+                      * parsers.dquote)
+                    + (parsers.squote
+                      * C((parsers.anyescaped - parsers.squote)^0)
+                      * parsers.squote)
+                    + C((parsers.anyescaped - parsers.dquote - parsers.space - P("}"))^1)
+
+parsers.attrpair    = Cg(C((parsers.attrid)^1)
                       * parsers.optionalspace * parsers.equal * parsers.optionalspace
                       * parsers.attrvalue)
                       * parsers.optionalspace^-1
 parsers.attrlist    = Cf(Ct("") * parsers.attrpair^0, rawset)
 
-parsers.class       = (P("-") * Cc("unnumbered")) + (parsers.period * C((parsers.identifier)^1))
+parsers.class       = (P("-") * Cc("unnumbered")) + (parsers.period * C((parsers.attrid)^1))
 parsers.classes     = (parsers.class * parsers.optionalspace)^0
 
-parsers.hashid      = parsers.hash * C((parsers.identifier)^1)
+parsers.hashid      = parsers.hash * C((parsers.alphanumeric + S("-_:."))^1)
 
 parsers.attributes  = P("{") * parsers.optionalspace
                       * Cg(parsers.hashid^-1) * parsers.optionalspace
@@ -176,7 +185,8 @@ parsers.attributes  = P("{") * parsers.optionalspace
                           return attr
                         end
 -- Raw attributes similar to Pandoc (=format key=value key2="value 2")
-parsers.raw              = parsers.equal * C((parsers.identifier)^1) * parsers.optionalspace
+parsers.rawid            = parsers.alphanumeric + S("_-")
+parsers.raw              = parsers.equal * C((parsers.rawid)^1) * parsers.optionalspace
 parsers.rawattributes    = P("{") * parsers.optionalspace
                           * parsers.raw * Cg(parsers.attrlist)
                           * parsers.optionalspace * P("}")


### PR DESCRIPTION
Closes #62 

Carefully reading Pandoc's code, I hope I got it right now:
1. attributes `key=value` pairs
    - The key must start with a letter, followed by alphanumeric characters or `_-:.` (rather than just `_-`)
    - The value may be double-quoted _or_ single-quoted, and has less restrictions (than initially implemented)
 2. class `.class` identifiers
    - Same rule as for attribute keys
 3. hash `#id` identifiers
    - The identifier syntax was relaxed in jgm/pandoc#7920 and they are thus different (allowed _not_ to start with a letter)
 4. raw `=raw` attributes
    - They have yet another syntax, consisting in alphanums and `_-` only