### PR TITLE
Allow references and notes in fenced divs

### DIFF
--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -1344,11 +1344,9 @@ function M.new(writer, options)
   larsers.FencedDiv = parsers.fenced_div_begin * increment_div_level(1)
                     * parsers.skipblanklines
                     * Ct( (V("Block") - parsers.fenced_div_end)^-1
-                        * (parsers.blanklines / function()
-                                              return writer.interblocksep
-                                            end
+                        * ( V("Blank")^0 / writer.interblocksep
                           * (V("Block") - parsers.fenced_div_end))^0)
-                    * parsers.skipblanklines
+                    * V("Blank")^0
                     * parsers.fenced_div_end * increment_div_level(-1)
                     / function (infostring, div)
                         local attr = lpeg.match(Cg(parsers.attributes), infostring)

--- a/tests/lunamark/ext_fenced_divs.test
+++ b/tests/lunamark/ext_fenced_divs.test
@@ -94,7 +94,9 @@ I am a _fenced_ div
 
 ::: {.cit custom-style=raggedleft}
 
-I am a _fenced_ div
+I am a _fenced_ div with [a reference][1]
+
+ [1]: https://foo.bar/
 
 :::
 
@@ -167,7 +169,7 @@ This is the end of a div</div>
 <div class="cit">I am a <em>fenced</em> div</div>
 
 <div class="cit">
-<p>I am a <em>fenced</em> div</p>
+<p>I am a <em>fenced</em> div with <a href="https://foo.bar/">a reference</a></p>
 </div>
 
 ::: {.some-classname} This is not a div

--- a/tests/lunamark/ext_fenced_divs.test
+++ b/tests/lunamark/ext_fenced_divs.test
@@ -1,4 +1,4 @@
-lunamark -Xfenced_divs,fenced_code_blocks
+lunamark -Xfenced_divs,fenced_code_blocks,notes
 <<<
 :::
 This is not a div
@@ -100,6 +100,14 @@ I am a _fenced_ div with [a reference][1]
 
 :::
 
+::: {.cit custom-style=raggedleft}
+
+I am a _fenced_ div with a note[^1]
+
+ [^1]: This is a note.
+
+:::
+
 ::: {.some-classname}
 This is not a div
 ```
@@ -172,8 +180,20 @@ This is the end of a div</div>
 <p>I am a <em>fenced</em> div with <a href="https://foo.bar/">a reference</a></p>
 </div>
 
+<div class="cit">
+<p>I am a <em>fenced</em> div with a note<sup><a href="#fn1" class="footnoteRef" id="fnref1">1</a></sup></p>
+</div>
+
 ::: {.some-classname} This is not a div
 <pre><code>:::
 </code></pre>
 
 <p>::: {.some-classname} This is not a div</p>
+
+<hr>
+
+<ol class="notes">
+<li id="fn1">
+<p>This is a note. <a href="#fnref1" class="footnoteBackLink">↩</a></p>
+</li>
+</ol>


### PR DESCRIPTION
Our implementation of fenced divs does not allow for reference definitions. This is because our implementation uses the `parsers.blankline` pattern instead of the `Blank` rule, which includes blank lines and references, among other things.

This pull request is a port of https://github.com/Witiko/markdown/pull/307.