### PR TITLE
fix: Style tag must be a block element

### DIFF
--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -462,7 +462,8 @@ parsers.block_keyword =
     parsers.keyword_exact("noscript") + parsers.keyword_exact("table") +
     parsers.keyword_exact("tbody") + parsers.keyword_exact("tfoot") +
     parsers.keyword_exact("thead") + parsers.keyword_exact("th") +
-    parsers.keyword_exact("td") + parsers.keyword_exact("tr")
+    parsers.keyword_exact("td") + parsers.keyword_exact("tr") +
+    parsers.keyword_exact("style")
 
 -- There is no reason to support bad html, so we expect quoted attributes
 parsers.htmlattributevalue


### PR DESCRIPTION
Closes #64 

**Test script**

```
local lunamark = require("lunamark")
local opts = { notes = true }
local writer = lunamark.writer.html.new(opts)
local parse = lunamark.reader.markdown.new(writer, opts)
local result, matadata = parse([[

<style>
.blue20 {
    color: blue;
    font-size: 20px;
}
.red {
    color: red;
    text-beffore: "_Hi_";
}
</style>

]])

print(result)
```

**Before**

```
<p><style> .blue20 { color: blue; font-size: 20px; } .red { color: red; text-beffore: &quot;<em>Hi</em>&quot;; } </style></p>
```
(Lines are not honored, and content is interpreted as Markdown)

**After**

```
<style>
.blue20 {
    color: blue;
    font-size: 20px;
}
.red {
    color: red;
    text-beffore: "_Hi_";
}
</style>
```

(As in original input)