### PR TITLE
Fix the CI pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,4 +34,4 @@ jobs:
           docker build -t jgm/lunamark .
       - name: Run unit tests
         run: |
-          docker run --rm -v "$PWD":/mnt -w /mnt --entrypoint /bin/sh jgm/lunamark -c 'make testdeps && make test'
+          docker run --rm -v "$PWD":/mnt -w /mnt --entrypoint /bin/bash jgm/lunamark -c 'set -e; eval "$(luarocks path)"; make testdeps; make test'

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,6 @@ testdeps:
 	luarocks --local install alt-getopt
 
 test:
-	LUAPATH="?.lua;lunamark/?.lua;lunamark/?/?.lua;$$LUAPATH"
 	LUNAMARK_EXTENSIONS="" bin/shtest ${TESTOPTS} -d tests/Markdown_1.0.3 -p ${PROG} ${OPTS}
 	LUNAMARK_EXTENSIONS="" bin/shtest ${TESTOPTS} -d tests/lunamark -p ${PROG} ${OPTS}
 


### PR DESCRIPTION
This PR fixes the CI pipeline by properly adding the luarocks install path to the `LUAPATH` environmental variable.