### PR TITLE
Support softbreaks, i.e., non-semantic line breaks.

### DIFF
--- a/lunamark/reader/markdown.lua
+++ b/lunamark/reader/markdown.lua
@@ -1172,7 +1172,7 @@ function M.new(writer, options)
                       + larsers.bqstart
                       + larsers.headerstart
                       + larsers.fencestart
-                    ) * parsers.spacechar^0 / writer.space
+                    ) * parsers.spacechar^0 / (writer.softbreak or writer.space)
 
   larsers.linebreak = parsers.spacechar^2 * larsers.Endline
   if options.escaped_line_breaks then

--- a/lunamark/writer/generic.lua
+++ b/lunamark/writer/generic.lua
@@ -43,6 +43,9 @@ setmetatable(W, meta)
 -- :   `minimize` (no space between blocks)
 -- :   `compact` (no extra blank lines between blocks)
 -- :   `default` (blank line between blocks)
+--
+-- `wrap_preserve`
+-- :   whether the line wrapping of the source text should be preserved
 function M.new(options)
 
 --- The table contains the following fields:
@@ -80,6 +83,8 @@ function M.new(options)
 
   --- A space (string).
   W.space = " "
+
+  W.softbreak = options.wrap_preserve and "\n" or " "
 
   --- Setup tasks at beginning of document.
   function W.start_document()

--- a/lunamark/writer/html.lua
+++ b/lunamark/writer/html.lua
@@ -26,6 +26,9 @@ local flatten, intersperse, map = util.flatten, util.intersperse, util.map
 -- :   `minimize` removes semantically insignificant white space.
 -- :   `compact` removes unneeded blank lines.
 -- :   `default` puts blank lines between block elements.
+--
+-- `wrap_preserve`
+-- :   whether the line wrapping of the source text should be preserved
 function M.new(options)
   options = options or {}
   local Html = xml.new(options)


### PR DESCRIPTION
The parser now uses the `softbreak` break of the writer for non-semantic line breaks. This is a backwards-compatible change, as it falls back to `space` if `softbreak` is not defined.

The generic writer is updated to allow enabling softbreaks by setting the `wrap_preserve` option to a truthy value.